### PR TITLE
WIP: Build on GHC 8.10

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,19 @@
+packages: .
+
+allow-newer: all
+
+source-repository-package
+    type: git
+    location: https://github.com/Avi-D-coder/loopbreaker.git
+    tag: 96a4351586b681927f2b0f7d50d6292281e55b4b
+
+source-repository-package
+    type: git
+    location: https://github.com/Avi-D-coder/polysemy.git
+    tag: 256da5bb03bb373e33f3338e29bf8a97b40953c0
+    subdir: polysemy-plugin
+
+source-repository-package
+    type: git
+    location: https://github.com/Avi-D-coder/polysemy.git
+    tag: 256da5bb03bb373e33f3338e29bf8a97b40953c0

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages: .
 
-allow-newer: all
+allow-newer: template-haskell, base, ghc, Cabal, Win32
+constraints: any.Cabal ==3.0.*
 
 source-repository-package
     type: git
@@ -10,10 +11,10 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/polysemy.git
-    tag: 256da5bb03bb373e33f3338e29bf8a97b40953c0
+    tag: 8ea93bcb0205b99c9bbc2fbc9651e0bb6750b252
     subdir: polysemy-plugin
 
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/polysemy.git
-    tag: 256da5bb03bb373e33f3338e29bf8a97b40953c0
+    tag: 8ea93bcb0205b99c9bbc2fbc9651e0bb6750b252

--- a/effects-benchmarks.cabal
+++ b/effects-benchmarks.cabal
@@ -11,6 +11,8 @@ category:            Web
 build-type:          Simple
 extra-source-files:  README.md
 
+ghc-options:         -Wall -Werror -O2 -flate-specialise
+
 common shared
   default-language:    Haskell2010
   ghc-options:         -Wall -Werror -O2 -flate-specialise
@@ -54,7 +56,7 @@ library instances-for-fused-effects
   exposed-modules: Fused.Stateful
                  , Fused.StatefulExcept
                  , Fused.HTTP
-  build-depends:   fused-effects >= 0.5
+  build-depends:   fused-effects ^>= 0.5
 
 library instances-for-freer-simple
   import:          shared
@@ -71,6 +73,7 @@ library instances-for-polysemy
                  , Poly.StatefulExcept
                  , Poly.HTTP
   build-depends:   polysemy ^>= 1.2
+                 , polysemy-plugin
 
 benchmark effects-benchmarks
   import:         shared

--- a/effects-benchmarks.cabal
+++ b/effects-benchmarks.cabal
@@ -56,7 +56,7 @@ library instances-for-fused-effects
   exposed-modules: Fused.Stateful
                  , Fused.StatefulExcept
                  , Fused.HTTP
-  build-depends:   fused-effects ^>= 0.5
+  build-depends:   fused-effects == 0.5.0.1
 
 library instances-for-freer-simple
   import:          shared
@@ -86,7 +86,7 @@ benchmark effects-benchmarks
                 , instances-for-polysemy
                 , instances-for-shallow
                 , instances-for-exteff
-                , dump-core
+                -- , dump-core
                 , gauge
                 , weigh
                 , polysemy

--- a/instances/Fused/Stateful.hs
+++ b/instances/Fused/Stateful.hs
@@ -2,7 +2,7 @@
 
 module Fused.Stateful where
 
-import Control.Effect (run, PureC)
+import Control.Effect (PureC)
 import Control.Effect.State.Lazy as State
 
 type StateM = StateC Int PureC

--- a/instances/Fused/StatefulExcept.hs
+++ b/instances/Fused/StatefulExcept.hs
@@ -2,7 +2,7 @@
 
 module Fused.StatefulExcept where
 
-import Control.Effect (run, PureC)
+import Control.Effect (PureC)
 import Control.Effect.State.Strict as State
 import Control.Effect.Error
 

--- a/instances/Poly/HTTP.hs
+++ b/instances/Poly/HTTP.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TemplateHaskell, KindSignatures, GADTs, FlexibleContexts, TypeOperators, LambdaCase #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
 
 module Poly.HTTP where
 

--- a/instances/Poly/Stateful.hs
+++ b/instances/Poly/Stateful.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds, TypeApplications #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
 
 module Poly.Stateful where
 

--- a/instances/Poly/StatefulExcept.hs
+++ b/instances/Poly/StatefulExcept.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TypeApplications, DataKinds #-}
+{-# OPTIONS_GHC -fplugin=Polysemy.Plugin #-}
+
 module Poly.StatefulExcept where
 
 import Polysemy


### PR DESCRIPTION
It builds and runs, but I suspect polysemy being a `source-repository-package` is breaking it's optimizations.
```swift
benchmarked Countdown/Put/fused-effects
time                 13.06 μs   (13.00 μs .. 13.13 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 13.03 μs   (13.01 μs .. 13.06 μs)
std dev              69.76 ns   (40.29 ns .. 126.4 ns)

benchmarked Countdown/Put/mtl
time                 6.632 μs   (6.607 μs .. 6.666 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.621 μs   (6.614 μs .. 6.635 μs)
std dev              32.19 ns   (20.99 ns .. 47.44 ns)

benchmarked Countdown/Put/polysemy
time                 6.863 ms   (6.786 ms .. 6.929 ms)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 6.550 ms   (6.493 ms .. 6.614 ms)
std dev              181.8 μs   (158.3 μs .. 212.0 μs)

benchmarked Countdown/Put/freer-simple
time                 1.616 ms   (1.599 ms .. 1.635 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.604 ms   (1.598 ms .. 1.615 ms)
std dev              26.31 μs   (15.26 μs .. 45.64 μs)

benchmarked Countdown/Put/extensible-effects
time                 1.759 ms   (1.739 ms .. 1.784 ms)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 1.756 ms   (1.744 ms .. 1.780 ms)
std dev              53.20 μs   (31.52 μs .. 79.61 μs)
variance introduced by outliers: 13% (moderately inflated)

benchmarked Countdown/Put/shallow
time                 321.9 μs   (318.2 μs .. 325.0 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 323.0 μs   (321.5 μs .. 325.5 μs)
std dev              6.709 μs   (4.332 μs .. 11.23 μs)

benchmarked Countdown/Put+Exc/fused-effects
time                 3.322 μs   (3.302 μs .. 3.350 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.318 μs   (3.309 μs .. 3.337 μs)
std dev              41.39 ns   (24.03 ns .. 72.66 ns)

benchmarked Countdown/Put+Exc/mtl
time                 3.305 μs   (3.287 μs .. 3.324 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.325 μs   (3.312 μs .. 3.364 μs)
std dev              67.69 ns   (28.88 ns .. 125.8 ns)

benchmarked Countdown/Put+Exc/polysemy
time                 7.514 ms   (7.437 ms .. 7.592 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 7.561 ms   (7.530 ms .. 7.627 ms)
std dev              133.9 μs   (68.07 μs .. 225.3 μs)

benchmarked Countdown/Put+Exc/freer-simple
time                 1.326 ms   (1.318 ms .. 1.337 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 1.321 ms   (1.316 ms .. 1.331 ms)
std dev              24.28 μs   (14.93 μs .. 42.46 μs)

benchmarked Countdown/Put+Exc/extensible-effects
time                 1.434 ms   (1.424 ms .. 1.445 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.425 ms   (1.420 ms .. 1.436 ms)
std dev              25.08 μs   (14.47 μs .. 46.27 μs)

benchmarked Countdown/Put+Exc/shallow
time                 66.81 μs   (66.52 μs .. 67.03 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 67.08 μs   (66.92 μs .. 67.73 μs)
std dev              983.5 ns   (202.5 ns .. 2.064 μs)

benchmarked HTTP/fused-effects
time                 3.269 μs   (3.239 μs .. 3.296 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 3.303 μs   (3.284 μs .. 3.365 μs)
std dev              102.8 ns   (43.42 ns .. 198.0 ns)
variance introduced by outliers: 13% (moderately inflated)

benchmarked HTTP/polysemy
time                 16.44 ms   (16.27 ms .. 16.67 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 16.55 ms   (16.43 ms .. 16.71 ms)
std dev              345.1 μs   (269.1 μs .. 441.0 μs)

benchmarked HTTP/extensible-effects
time                 1.997 ms   (1.976 ms .. 2.023 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 1.962 ms   (1.953 ms .. 1.972 ms)
std dev              33.30 μs   (25.56 μs .. 43.50 μs)

benchmarked HTTP/Deep embedding
time                 2.464 ms   (2.447 ms .. 2.481 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 2.485 ms   (2.474 ms .. 2.512 ms)
std dev              55.95 μs   (27.97 μs .. 105.6 μs)

benchmarked HTTP/Shallow embedding
time                 18.09 μs   (18.02 μs .. 18.19 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 18.14 μs   (18.09 μs .. 18.29 μs)
std dev              273.6 ns   (148.4 ns .. 549.1 ns)

benchmarked HTTP/freer-simple
time                 1.774 ms   (1.760 ms .. 1.796 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 1.818 ms   (1.809 ms .. 1.832 ms)
std dev              38.12 μs   (28.16 μs .. 56.57 μs)

*** Space benchmarks (these will take some time to run) ***

Countdown

  Case                Allocated  GCs
  fused-effects              40    0
  mtl                        40    0
  polysemy                4,656    0
  freer-simple            1,096    0
  extensible-effects      1,304    0
  shallow                   232    0

Countdown + exc

  Case                Allocated  GCs
  fused-effects              16    0
  mtl                        16    0
  polysemy                4,600    0
  freer-simple              544    0
  extensible-effects        664    0
  shallow                     0    0
```